### PR TITLE
Split each part up to run independently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ dmypy.json
 .pyre/
 *.jpg
 creds.json
+*.zip

--- a/README.md
+++ b/README.md
@@ -13,6 +13,27 @@ Fill out `.env` with the fields in `example.env`.
 
 ## Run
 
+There's 3 stages:
+1. Download photos from Discord
+2. Crop them
+3. Make collage
+
+For downloading only
 ```
-python -m class_photo
+python -m class_photo --bot
+```
+
+For cropping only
+```
+python -m class_photo --crop
+```
+
+For collage only
+```
+python -m class_photo --collage
+```
+
+For everything
+```
+python -m class_photo --all
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Setup
 
 ```
-python3 -m venv .venv
+virtualenv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 ```

--- a/class_photo/__main__.py
+++ b/class_photo/__main__.py
@@ -14,10 +14,6 @@ def get_locations(dir):
 
 if __name__ == "__main__":
     load_dotenv()
-    try:
-        os.mkdir("img")
-    except:
-        print("Directory already exists! Overwriting existing photos.")
 
     if len(sys.argv) == 2:
         if sys.argv[1] == "--bot":

--- a/class_photo/__main__.py
+++ b/class_photo/__main__.py
@@ -14,6 +14,11 @@ def get_locations(dir):
 
 if __name__ == "__main__":
     load_dotenv()
+    try:
+        os.mkdir("img")
+    except:
+        print("Directory already exists! Overwriting existing photos.")
+
     if len(sys.argv) == 2:
         if sys.argv[1] == "--bot":
             bot.main()
@@ -32,3 +37,5 @@ if __name__ == "__main__":
             face.crop(discord_locations)
             cropped_locations = get_locations("img/cropped")
             collage.make_collage(cropped_locations)
+    else:
+        print("Wrong arguments. Consult the README for more information. Only 1 argument at a time.")

--- a/class_photo/__main__.py
+++ b/class_photo/__main__.py
@@ -1,4 +1,34 @@
+import os
+import sys
+from dotenv import load_dotenv
 from . import bot
+from . import face
+from . import collage
+
+def get_locations(dir):
+    total = len([name for name in os.listdir(dir) if os.path.isfile(os.path.join(dir, name))])
+    imgs = []
+    for index in range(total):
+        imgs.append(f"{dir}/{index}.jpg")
+    return imgs
 
 if __name__ == "__main__":
-    bot.main()
+    load_dotenv()
+    if len(sys.argv) == 2:
+        if sys.argv[1] == "--bot":
+            bot.main()
+
+        elif sys.argv[1] == "--crop":
+            locations = get_locations("img/discord")
+            face.crop(locations)
+
+        elif sys.argv[1] == "--collage":
+            locations = get_locations("img/cropped")
+            collage.make_collage(locations)
+
+        elif sys.argv[1] == "--all":
+            bot.main()
+            discord_locations = get_locations("img/discord")
+            face.crop(discord_locations)
+            cropped_locations = get_locations("img/cropped")
+            collage.make_collage(cropped_locations)

--- a/class_photo/bot.py
+++ b/class_photo/bot.py
@@ -9,7 +9,6 @@ from . import face
 
 bot = commands.Bot('-cp')
 
-
 def main():
     bot.run(os.getenv("TOKEN"))
 
@@ -19,11 +18,22 @@ async def on_ready():
     await get_photos()
     await bot.logout()
 
-async def get_photos():
-
+async def get_photos():   
     urls = await get_all_urls()
     print(f"Collected {len(urls)} photo urls in total")
-    imgs_location = []
+    
+    try:
+        os.mkdir("img")
+        print("Created img directory!")
+    except FileExistsError:
+        print("img directory already exists!")
+
+    try:
+        os.mkdir("img/discord")
+        print("Created discord directory!")
+    except FileExistsError:
+        print("discord directory already exists! Overwriting existing photos.")
+
     for index, url in enumerate(urls):
         await save_photo(index, url)
 
@@ -43,10 +53,6 @@ async def save_photo(index, url):
     try:
         response = requests.get(url[0], timeout=5)
         try:
-            try:
-                os.mkdir("img/discord")
-            except FileExistsError:
-                pass
             response.raise_for_status()
             image = Image.open(BytesIO(response.content))
             image = rotate_if_exif_specifies(image)

--- a/class_photo/bot.py
+++ b/class_photo/bot.py
@@ -9,27 +9,25 @@ from . import face
 
 bot = commands.Bot('-cp')
 
+
 def main():
-    load_dotenv()
     bot.run(os.getenv("TOKEN"))
 
 @bot.event
 async def on_ready():
     print('Bot Online!')
-    urls = await get_photos()
-    face.crop(urls)
+    await get_photos()
     await bot.logout()
 
 async def get_photos():
 
     urls = await get_all_urls()
     print(f"Collected {len(urls)} photo urls in total")
-
-    for url in urls:
-        await save_photo(url)
+    imgs_location = []
+    for index, url in enumerate(urls):
+        await save_photo(index, url)
 
     print(f"Saved all {len(urls)} photos!")
-    return urls
 
 async def get_all_urls():
     urls = []
@@ -41,19 +39,18 @@ async def get_all_urls():
             urls.append((message.attachments[0].url, message.id))
     return urls
 
-async def save_photo(url):
+async def save_photo(index, url):
     try:
         response = requests.get(url[0], timeout=5)
         try:
             try:
-                os.mkdir("img")
                 os.mkdir("img/discord")
             except FileExistsError:
                 pass
             response.raise_for_status()
             image = Image.open(BytesIO(response.content))
             image = rotate_if_exif_specifies(image)
-            image.convert('RGB').save(f"img/discord/{url[1]}.jpg", optimize=True)
+            image.convert('RGB').save(f"img/discord/{index}.jpg", optimize=True)
 
         except requests.HTTPError:
             print('HTTP error')

--- a/class_photo/collage.py
+++ b/class_photo/collage.py
@@ -22,15 +22,15 @@ def make_collage(imgs):
         remainder_test = (rows_test * cols_test) - index
 
     while (cols * rows) > len(imgs):
-        padded_img = Image.new('RGB', (1000, 1000), (30, 83, 159))
+        padded_img = Image.new('RGB', (200, 200), (30, 83, 159))
         output_filename = f"img/cropped/{index}.jpg"
         index += 1
         padded_img.seek(0)
         padded_img.save(output_filename)
         imgs.append(output_filename)
 
-    width = 1000 * cols
-    height = 1000 * rows
+    width = 200 * cols
+    height = 200 * rows
     thumbnail_width = width//cols
     thumbnail_height = height//rows
     size = thumbnail_width, thumbnail_height

--- a/class_photo/face.py
+++ b/class_photo/face.py
@@ -7,8 +7,10 @@ from . import collage
 def crop(imgs):
     try:
         os.mkdir("img/cropped")
+        print("Created cropped directory!")
     except FileExistsError:
-        pass        
+        print("cropped directory already exists! Overwriting existing photos.")
+
     print("Cropping...")
     img_filenames = []
     for index, img in enumerate(imgs):

--- a/class_photo/face.py
+++ b/class_photo/face.py
@@ -12,14 +12,12 @@ def crop(imgs):
     print("Cropping...")
     img_filenames = []
     for index, img in enumerate(imgs):
-        with open(f"img/discord/{img[1]}.jpg", 'rb') as image:
+        with open(f"img/discord/{index}.jpg", 'rb') as image:
             faces = detect_face(image)
             output_filename = f"img/cropped/{index}.jpg"
             img_filenames.append(output_filename)
             image.seek(0)
             crop_faces(image, faces, output_filename)
-
-    collage.make_collage(img_filenames)
 
 def detect_face(face_file, max_results=4):
     client = vision.ImageAnnotatorClient()
@@ -77,5 +75,5 @@ def crop_faces(image, faces, output_filename):
 
     box2 = (left,top,right,bottom)
     new_im = im.crop(box2)
-    new_im = new_im.resize((1000,1000), Image.ANTIALIAS)
+    new_im = new_im.resize((200,200), Image.ANTIALIAS)
     new_im.save(output_filename)


### PR DESCRIPTION
Allows each section to be run on its own in case cropping has bugs. Commands can be found in the README.

## Changes

- Discord photos now saved as numbers starting at 0 rather than IDs
- Now requires arguments when run in a terminal. Can run the 3 steps together or individually
- Reduced the square crop to 200x200 instead of 1000x1000
- Add Google Cloud instructions for setting up a service account
- Change virtual environment instructions to use `virtualenv` to prevent errors with Google Cloud Vision